### PR TITLE
Launch the dashboard in default browser

### DIFF
--- a/VisualStudio/allversions/QuantifiedDevVisualStudioExtension/QuantifiedDevVisualStudioExtension/MyControl.xaml.cs
+++ b/VisualStudio/allversions/QuantifiedDevVisualStudioExtension/QuantifiedDevVisualStudioExtension/MyControl.xaml.cs
@@ -29,7 +29,7 @@ namespace N1self.C1selfVisualStudioExtension
         private void Register(object sender, RoutedEventArgs e)
         {
             string uri = string.Format("https://api.1self.co/v1/streams/{0}/events/Computer,Software/Build,Finish/count/daily/barchart?readToken={1}", Settings.Default.StreamId, Settings.Default.ReadToken);
-            System.Diagnostics.Process.Start("iexplore.exe", uri);
+            System.Diagnostics.Process.Start(uri);
             
         }
     }


### PR DESCRIPTION
You can launch a url directly using `Process.Start` and Windows will use the default browser to load it.
